### PR TITLE
Use read-write locks to improve cpu utilization in multi-threaded scenarios.

### DIFF
--- a/numpy/core/src/common/npy_hashtable.h
+++ b/numpy/core/src/common/npy_hashtable.h
@@ -14,7 +14,7 @@ typedef struct {
     npy_intp size;  /* current size */
     npy_intp nelem;  /* number of elements */
 #ifdef PY_NOGIL
-    _PyMutex mutex;
+    pthread_rwlock_t rw_lock;
 #endif
 } PyArrayIdentityHash;
 


### PR DESCRIPTION
Use read-write locks to improve cpu utilization in multi-threaded scenarios.

Test code:

```python
import time
import numpy as np
from threading import Thread

def fib(n):
    if n < 2: return np.ones(25, dtype=np.int64)
    return fib(n-1) + fib(n-2)

def entry():
    history = []
    for i in range(10):
        start_time = time.time()
        fib(34)
        history.append(time.time() - start_time)
    min_val, max_val, mean_val, var_val = np.min(history), np.max(history), np.mean(history), np.var(history)
    print(f"min={min_val}, max={max_val}, mean={mean_val}, var={var_val}")


def main():
    threads = []
    for _ in range(15):
        thread = Thread(target=entry)
        threads.append(thread)
        thread.start()

    for thread in threads:
        thread.join()


if __name__ == "__main__":
    main()
```